### PR TITLE
Correct order of operations when calculating check digit

### DIFF
--- a/lib/isni.rb
+++ b/lib/isni.rb
@@ -38,7 +38,7 @@ class ISNI
         accum = (accum + i) * 2
       end
     end
-    remainder = 12 - (sum % 11) % 11
+    remainder = (12 - (sum % 11)) % 11
     if remainder == 10
       check = "X"
     else

--- a/spec/isni_spec.rb
+++ b/spec/isni_spec.rb
@@ -14,6 +14,9 @@ describe "The ISNI class" do
       expect(ISNI.valid?("0000-0002-9534-656X")).to eq true
       expect(ISNI.valid?("000000029534656X")).to eq true
       expect(ISNI.valid?("0000000122822548")).to eq true
+      expect(ISNI.valid?("0000-0003-2330-9361")).to eq true
+      expect(ISNI.valid?("0000-0003-1279-3709")).to eq true
+      expect(ISNI.valid?("0000 0002 9079 593X ")).to eq true
     end
 
     it "should identify an invalid ISNI" do


### PR DESCRIPTION
A certain subset of valid ORCIDs would fail when provided to this library because the final modulus operation was being applied out of order. An example is `"0000-0003-2330-9361”`, which now passes.